### PR TITLE
Update gameobject-types.ts

### DIFF
--- a/src/app/shared/constants/gameobject-types.ts
+++ b/src/app/shared/constants/gameobject-types.ts
@@ -103,7 +103,7 @@ GO_DATA_FIELDS[6][18] = { name: 'requireLOS', tooltip: null };
 
 GO_DATA_FIELDS[7] = [];
 GO_DATA_FIELDS[7][0] = { name: 'chairSlots', tooltip: 'number of players that can sit down on it' };
-GO_DATA_FIELDS[7][1] = { name: 'chairOrientation', tooltip: 'number of usable side' };
+GO_DATA_FIELDS[7][1] = { name: 'height', tooltip: 'null' };
 GO_DATA_FIELDS[7][2] = { name: 'onlyCreatorUse', tooltip: null };
 GO_DATA_FIELDS[7][3] = { name: 'triggeredEvent', tooltip: null };
 GO_DATA_FIELDS[7][4] = { name: 'conditionID1', tooltip: null };


### PR DESCRIPTION
Noticed this error while doing 

https://github.com/azerothcore/azerothcore-wotlk/pull/12708

Change chairOrientation to height
![keira3_orientation](https://user-images.githubusercontent.com/74299960/184349968-ea238ed1-7da0-43af-b988-102694d20986.png)


Gameobject.h
```
        //7 GAMEOBJECT_TYPE_CHAIR
        struct
        {
            uint32 slots;                                   //0
            uint32 height;                                  //1
            uint32 onlyCreatorUse;                          //2
            uint32 triggeredEvent;                          //3
        } chair;
```
Gameobject.c
```
        //Sitting: Wooden bench, chairs enzz
        case GAMEOBJECT_TYPE_CHAIR:                         //7
...
                        player->SetStandState(UNIT_STAND_STATE_SIT_LOW_CHAIR + info->chair.height);
```